### PR TITLE
Adjusting max duration to support longer server actions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,6 @@ import { Providers } from '@/components/providers'
 import { Header } from '@/components/header'
 import { Toaster } from '@/components/ui/sonner'
 import Starfield from '@/components/ui/backgrounds/Starfield'
-import ThreeStarfield from "@/components/ui/backgrounds/ThreeStarfield";
 
 const chakra = Chakra_Petch({
   weight: '400',

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/**/*": {
+      "maxDuration": 59
+    }
+  }
+}


### PR DESCRIPTION
1. Found out that Vercel has a default timeout set to 10 seconds for API calls, this applies to server actions as well. Have to extend maxDuration out